### PR TITLE
feat: context api 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,7 @@ export default function App() {
   return (
     <>
       <Global styles={globalStyle} />
-      <Board></Board>
+      <Board />
     </>
   );
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -16,5 +16,6 @@ const Container = styled.header`
   h1 {
     margin: 0;
     font-size: 70px;
+    color: #ead7d7;
   }
 `;

--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -1,50 +1,65 @@
 import React, { useState } from 'react';
 import styled from '@emotion/styled';
 import * as api from '../api/todo';
-import { Todo } from '../types/Todo';
-import TodosHeader from './TodosHeader';
+import { useTodosDispatch, Todo } from '../contexts/TodosContext';
 
-type todoProps = {
-  checked: boolean;
+type TodoItemProps = {
+  todo: Todo;
 };
 
-export default function TodoItem(props: Todo) {
+export default function TodoItem({ todo }: TodoItemProps) {
+  const dispatch = useTodosDispatch();
   const [edit, setEdit] = useState(false);
-  const [content, setContent] = useState(props.content);
+  const [task, setTask] = useState(todo.content);
+  const { completed } = todo;
+
   const handleEditClick = () => {
     setEdit(true);
   };
   const handleEditChange = (e: any) => {
-    setContent(e.target.value);
+    setTask(e.target.value);
   };
-  const handleEditSubmit = (e: any) => {
+  const handleEditSubmit = (e: React.FormEvent) => {
     e.preventDefault;
-    api.updateTodo(props);
+    api.updateTodo(todo);
     api.getTodos();
     setEdit(false);
   };
-  const handleDeleteClick = () => {
+  const onRemove = () => {
+    dispatch({
+      type: 'REMOVE',
+      id: todo.id,
+    });
     alert('정말 삭제하시겠습니까?');
-    api.deleteTodo(props.id);
+    api.deleteTodo(todo.id);
     api.getTodos();
+    console.log('삭제돼랏');
   };
+
+  const onToggle = () => {
+    dispatch({
+      type: 'TOGGLE',
+      id: todo.id,
+    });
+  };
+
   return (
     <Container>
-      <CheckBox checked={false}></CheckBox>
+      <CheckBox completed={false} onClick={onToggle} />
       {edit ? (
         <form onSubmit={handleEditSubmit}>
           <EditInput
             onChange={handleEditChange}
             type="text"
-            value={content}
+            value={task}
           ></EditInput>
         </form>
       ) : (
         <>
-          <Content checked={false} onDoubleClick={handleEditClick}>
-            {content}
+          <Content completed={false} onDoubleClick={handleEditClick}>
+            {task}
           </Content>
-          <DeleteButton onClick={handleDeleteClick}>X</DeleteButton>
+          <DeleteButton onClick={onRemove}>X</DeleteButton>
         </>
       )}
     </Container>
@@ -53,22 +68,22 @@ export default function TodoItem(props: Todo) {
 
 const CHECKED_IMAGE_URL = `data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20width%3D%2240%22%20height%3D%2240%22%20viewBox%3D%22-10%20-18%20100%20135%22%3E%3Ccircle%20cx%3D%2250%22%20cy%3D%2250%22%20r%3D%2250%22%20fill%3D%22none%22%20stroke%3D%22%23bddad5%22%20stroke-width%3D%223%22/%3E%3Cpath%20fill%3D%22%235dc2af%22%20d%3D%22M72%2025L42%2071%2027%2056l-4%204%2020%2020%2034-52z%22/%3E%3C/svg%3E`;
 const UNCHECKED_IMAGE_URL = `data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20width%3D%2240%22%20height%3D%2240%22%20viewBox%3D%22-10%20-18%20100%20135%22%3E%3Ccircle%20cx%3D%2250%22%20cy%3D%2250%22%20r%3D%2250%22%20fill%3D%22none%22%20stroke%3D%22%23ededed%22%20stroke-width%3D%223%22/%3E%3C/svg%3E`;
-const CheckBox = styled.div<todoProps>`
+const CheckBox = styled.div<TodoItemProps>`
   width: 40px;
   height: 40px;
   cursor: pointer;
-  background-image: ${props =>
-    props.checked
+  background-image: ${todo =>
+    todo.todo.completed
       ? `url('${CHECKED_IMAGE_URL}')`
       : `url('${UNCHECKED_IMAGE_URL}')`};
 `;
 
-const Content = styled.div<todoProps>`
+const Content = styled.div<TodoItemProps>`
   width: calc(100% - 95px);
   padding: 15px;
   word-break: break-all;
-  color: ${props => (props.checked ? `#777` : `#000`)};
-  text-decoration: ${props => (props.checked ? `line-through` : `none`)};
+  color: ${todo => (todo.todo.completed ? `#777` : `#000`)};
+  text-decoration: ${todo => (todo.todo.completed ? `line-through` : `none`)};
 `;
 
 const Container = styled.div`
@@ -86,18 +101,6 @@ const Container = styled.div`
     &::after {
       display: block;
     }
-  }
-  &::after {
-    content: 'X';
-    position: absolute;
-    display: none;
-    width: 40px;
-    height: 40px;
-    right: 40px;
-    bottom: 10px;
-    cursor: pointer;
-    font-weight: bold;
-    color: red;
   }
 `;
 const DeleteButton = styled.span`

--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -1,15 +1,21 @@
 import React from 'react';
 import styled from '@emotion/styled';
+import { Todo } from '../types/Todo';
 
 type todoProps = {
   checked: boolean;
 };
 
-export default function Todo() {
+export type TodoItemProps = {
+  todo: Todo;
+};
+
+export default function TodoItem({ todo }: TodoItemProps) {
+  const { content, completed } = todo;
   return (
     <Container>
-      <CheckBox checked={true}></CheckBox>
-      <Content checked={true}>내용이 들어겠습니다!</Content>
+      <CheckBox checked={completed}></CheckBox>
+      <Content checked={completed}>{content}</Content>
     </Container>
   );
 }

--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -1,15 +1,52 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled from '@emotion/styled';
+import * as api from '../api/todo';
+import { Todo } from '../types/Todo';
+import TodosHeader from './TodosHeader';
 
 type todoProps = {
   checked: boolean;
 };
 
-export default function Todo() {
+export default function TodoItem(props: Todo) {
+  const [edit, setEdit] = useState(false);
+  const [content, setContent] = useState(props.content);
+  const handleEditClick = () => {
+    setEdit(true);
+  };
+  const handleEditChange = (e: any) => {
+    setContent(e.target.value);
+  };
+  const handleEditSubmit = (e: any) => {
+    e.preventDefault;
+    api.updateTodo(props);
+    api.getTodos();
+    setEdit(false);
+  };
+  const handleDeleteClick = () => {
+    alert('정말 삭제하시겠습니까?');
+    api.deleteTodo(props.id);
+    api.getTodos();
+  };
   return (
     <Container>
-      <CheckBox checked={true}></CheckBox>
-      <Content checked={true}>내용이 들어겠습니다!</Content>
+      <CheckBox checked={false}></CheckBox>
+      {edit ? (
+        <form onSubmit={handleEditSubmit}>
+          <EditInput
+            onChange={handleEditChange}
+            type="text"
+            value={content}
+          ></EditInput>
+        </form>
+      ) : (
+        <>
+          <Content checked={false} onDoubleClick={handleEditClick}>
+            {content}
+          </Content>
+          <DeleteButton onClick={handleDeleteClick}>X</DeleteButton>
+        </>
+      )}
     </Container>
   );
 }
@@ -62,4 +99,21 @@ const Container = styled.div`
     font-weight: bold;
     color: red;
   }
+`;
+const DeleteButton = styled.span`
+  position: absolute;
+  display: block;
+  width: 40px;
+  height: 40px;
+  right: 40px;
+  bottom: 10px;
+  cursor: pointer;
+  font-weight: bold;
+  color: red;
+`;
+const EditInput = styled.input`
+  width: calc(100% - 95px);
+  padding: 15px;
+  word-break: break-all;
+  color: #000;
 `;

--- a/src/components/TodoList.tsx
+++ b/src/components/TodoList.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import TodoItem from './TodoItem';
+import * as api from '../api/todo';
+
+export default function TodoList() {
+  const todos = api.getTodos();
+
+  return (
+    <ul>
+      {todos.map(todo => (
+        <TodoItem key={todo.id} todo={todo} />
+      ))}
+    </ul>
+  );
+}

--- a/src/components/TodoList.tsx
+++ b/src/components/TodoList.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import TodoItem from './TodoItem';
 import * as api from '../api/todo';
+import { useTodoState } from '../contexts/todoContext';
 
 export default function TodoList() {
-  const todos = api.getTodos();
+  //const todos = api.getTodos();
+  const todos = useTodoState();
 
   return (
     <ul>

--- a/src/components/TodosHeader.tsx
+++ b/src/components/TodosHeader.tsx
@@ -1,16 +1,29 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import styled from '@emotion/styled';
+import { TodoContext } from '../context/context';
+import * as api from '../api/todo';
 
 type toggleCheckAllProps = {
   checked: boolean;
 };
 
 export default function TodosHeader() {
+  const [content, setContent] = useState('');
+  const handleChange = (e: any) => {
+    setContent(e.target.value);
+  };
+  const handleSubmit = () => {
+    api.createTodo(content);
+  };
   return (
     <Container>
       <ToggleCheckAll checked={true} />
-      <InputWrapper>
-        <Input placeholder="할일을 입력해 보세요!" />
+      <InputWrapper onSubmit={handleSubmit}>
+        <Input
+          value={content}
+          onChange={handleChange}
+          placeholder="할일을 입력해 보세요!"
+        ></Input>
       </InputWrapper>
     </Container>
   );
@@ -42,7 +55,7 @@ const ToggleCheckAll = styled.div<toggleCheckAllProps>`
   }
 `;
 
-const InputWrapper = styled.div`
+const InputWrapper = styled.form`
   width: calc(100% - 95px);
   height: 65px;
   padding: 15px;

--- a/src/components/TodosHeader.tsx
+++ b/src/components/TodosHeader.tsx
@@ -1,27 +1,34 @@
 import React, { useCallback, useState } from 'react';
 import styled from '@emotion/styled';
-import { TodoContext } from '../context/context';
-import * as api from '../api/todo';
+import { useTodosDispatch } from '../contexts/TodosContext';
 
 type toggleCheckAllProps = {
   checked: boolean;
 };
 
 export default function TodosHeader() {
-  const [content, setContent] = useState('');
-  const handleChange = (e: any) => {
-    setContent(e.target.value);
+  const [task, setTask] = useState('');
+  const dispatch = useTodosDispatch();
+
+  const onChange = useCallback((e: any) => {
+    setTask(e.target.value);
+  }, []);
+
+  const onSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    //api.createTodo(task);
+    dispatch({ type: 'CREATE', content: task });
+    setTask('');
   };
-  const handleSubmit = () => {
-    api.createTodo(content);
-  };
+
   return (
     <Container>
       <ToggleCheckAll checked={true} />
-      <InputWrapper onSubmit={handleSubmit}>
+      <InputWrapper onSubmit={onSubmit}>
         <Input
-          value={content}
-          onChange={handleChange}
+          value={task}
+          type="text"
+          onChange={onChange}
           placeholder="할일을 입력해 보세요!"
         ></Input>
       </InputWrapper>

--- a/src/components/TodosHeader.tsx
+++ b/src/components/TodosHeader.tsx
@@ -10,7 +10,7 @@ export default function TodosHeader() {
     <Container>
       <ToggleCheckAll checked={true} />
       <InputWrapper>
-        <Input placeholder="할일을 입력해 보세요!"></Input>
+        <Input placeholder="할일을 입력해 보세요!" />
       </InputWrapper>
     </Container>
   );

--- a/src/context/context.ts
+++ b/src/context/context.ts
@@ -1,0 +1,3 @@
+import React from 'react';
+
+export const TodoContext = React.createContext();

--- a/src/context/context.ts
+++ b/src/context/context.ts
@@ -1,3 +1,0 @@
-import React from 'react';
-
-export const TodoContext = React.createContext();

--- a/src/contexts/TodosContext.tsx
+++ b/src/contexts/TodosContext.tsx
@@ -1,0 +1,77 @@
+import React, { createContext, Dispatch, useReducer, useContext } from 'react';
+import * as api from '../api/todo';
+
+export type Todo = {
+  id: number;
+  content: string;
+  completed: boolean;
+  createDatetime: string;
+  updateDatetime?: string | null;
+  completedDatetime?: string | null;
+};
+
+type TodosState = Todo[];
+
+const TodosStateContext = createContext<TodosState | undefined>(undefined);
+
+type Action =
+  | { type: 'CREATE'; content: string }
+  | { type: 'EDIT'; id: number }
+  | { type: 'TOGGLE'; id: number }
+  | { type: 'REMOVE'; id: number };
+
+type TodosDispatch = Dispatch<Action>;
+
+const TodosDispatchContext = createContext<TodosDispatch | undefined>(
+  undefined,
+);
+
+function todosReducer(state: TodosState, action: Action): TodosState {
+  if (!state) new Error('state not found');
+  switch (action.type) {
+    case 'CREATE':
+      return state.concat({
+        content: action.content,
+        id: new Date().getTime(),
+        completed: false,
+        createDatetime: new Date().toString(),
+      });
+    case 'EDIT':
+    case 'TOGGLE':
+      return state.map(todo =>
+        todo.id === action.id ? { ...todo, completed: !todo.completed } : todo,
+      );
+    case 'REMOVE':
+      return state.filter(todo => todo.id !== action.id);
+    default:
+      throw new Error('Unhandled action');
+  }
+}
+
+export function TodosContextProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [todos, dispatch] = useReducer(todosReducer, api.getTodos());
+
+  return (
+    <TodosDispatchContext.Provider value={dispatch}>
+      <TodosStateContext.Provider value={todos}>
+        {children}
+      </TodosStateContext.Provider>
+    </TodosDispatchContext.Provider>
+  );
+}
+
+export function useTodosState() {
+  const state = useContext(TodosStateContext);
+  if (!state) throw new Error('TodosProvider not found');
+  return state;
+}
+
+export function useTodosDispatch() {
+  const dispatch = useContext(TodosDispatchContext);
+  if (!dispatch) throw new Error('TodosProvider not found');
+  return dispatch;
+}

--- a/src/contexts/todoContext.tsx
+++ b/src/contexts/todoContext.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, Dispatch, useContext, useReducer } from 'react';
-
 import { Todo, Status } from '../types/Todo';
+import * as api from '../api/todo';
 
 type TodoState = {
   todos: Todo[];
@@ -54,8 +54,9 @@ const reducer = (state: TodoState, action: Action): TodoState => {
         // TODO: status 가 바뀌었을 때 action.status 값을 이용하여 todos 가 업데이트 되도록 수정하기
         // todos:
       };
+    default:
+      throw new Error('Unhandled action');
   }
-  return state;
 };
 
 const TodoStateContext = createContext<TodoState | null>(null);

--- a/src/contexts/todoContext.tsx
+++ b/src/contexts/todoContext.tsx
@@ -24,10 +24,11 @@ const initialState = {
 const reducer = (state: TodoState, action: Action): TodoState => {
   switch (action.type) {
     case 'CREATE_TODO':
+      const todos = api.getTodos();
       return {
         ...state,
         // TODO: todo가 생성 되었을 때 action.todo 값을 이용하여 todos 가 업데이트 되도록 수정하기
-        // todos:
+        todo: action.todo,
       };
     case 'UPDATE_TODO':
       return {
@@ -57,6 +58,7 @@ const reducer = (state: TodoState, action: Action): TodoState => {
     default:
       throw new Error('Unhandled action');
   }
+  return state;
 };
 
 const TodoStateContext = createContext<TodoState | null>(null);

--- a/src/pages/Board.tsx
+++ b/src/pages/Board.tsx
@@ -12,12 +12,12 @@ import TodoProvider from '../contexts/todoContext';
 export default function Board() {
   return (
     <BoardLayout>
-      <TodosContextProvider>
+      <TodoProvider>
         <Header />
         <TodosHeader />
         <TodoList />
         <TodosFooter />
-      </TodosContextProvider>
+      </TodoProvider>
     </BoardLayout>
   );
 }

--- a/src/pages/Board.tsx
+++ b/src/pages/Board.tsx
@@ -1,21 +1,23 @@
 /* eslint-disable react/prop-types */
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useState } from 'react';
 import styled from '@emotion/styled';
 import Header from '../components/Header';
 import TodosHeader from '../components/TodosHeader';
 import TodoItem from '../components/TodoItem';
 import TodosFooter from '../components/TodosFooter';
-import { TodoContext } from '../context/context';
+import { TodosContextProvider, useTodosState } from '../contexts/TodosContext';
 import * as api from '../api/todo';
 import { Todo } from '../types/Todo';
 
 export default function Board() {
   return (
     <BoardLayout>
-      <Header />
-      <TodosHeader />
-      <TodoList />
-      <TodosFooter />
+      <TodosContextProvider>
+        <Header />
+        <TodosHeader />
+        <TodoList />
+        <TodosFooter />
+      </TodosContextProvider>
     </BoardLayout>
   );
 }
@@ -29,18 +31,12 @@ const BoardLayout = styled.section`
 `;
 
 const TodoList = () => {
-  const todos = api.getTodos();
+  const todos = useTodosState();
 
   return (
     <div>
       {todos.map(todo => (
-        <TodoItem
-          key={todo.id}
-          id={todo.id}
-          content={todo.content}
-          completed={todo.completed}
-          createDatetime={todo.createDatetime}
-        />
+        <TodoItem key={todo.id} todo={todo} />
       ))}
     </div>
   );

--- a/src/pages/Board.tsx
+++ b/src/pages/Board.tsx
@@ -1,19 +1,20 @@
-import React from 'react';
+/* eslint-disable react/prop-types */
+import React, { useCallback, useRef, useState } from 'react';
 import styled from '@emotion/styled';
-
 import Header from '../components/Header';
 import TodosHeader from '../components/TodosHeader';
-import Todo from '../components/Todo';
+import TodoItem from '../components/TodoItem';
 import TodosFooter from '../components/TodosFooter';
+import { TodoContext } from '../context/context';
+import * as api from '../api/todo';
+import { Todo } from '../types/Todo';
 
 export default function Board() {
   return (
     <BoardLayout>
       <Header />
       <TodosHeader />
-      <TodoList>
-        <Todo />
-      </TodoList>
+      <TodoList />
       <TodosFooter />
     </BoardLayout>
   );
@@ -27,4 +28,20 @@ const BoardLayout = styled.section`
   border-radius: 5px;
 `;
 
-const TodoList = styled.div``;
+const TodoList = () => {
+  const todos = api.getTodos();
+
+  return (
+    <div>
+      {todos.map(todo => (
+        <TodoItem
+          key={todo.id}
+          id={todo.id}
+          content={todo.content}
+          completed={todo.completed}
+          createDatetime={todo.createDatetime}
+        />
+      ))}
+    </div>
+  );
+};

--- a/src/pages/Board.tsx
+++ b/src/pages/Board.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import styled from '@emotion/styled';
-
 import Header from '../components/Header';
 import TodosHeader from '../components/TodosHeader';
-import Todo from '../components/Todo';
+import TodoList from '../components/TodoList';
 import TodosFooter from '../components/TodosFooter';
 import TodoProvider from '../contexts/todoContext';
 
@@ -13,9 +12,7 @@ export default function Board() {
       <Header />
       <TodoProvider>
         <TodosHeader />
-        <TodoList>
-          <Todo />
-        </TodoList>
+        <TodoList />
         <TodosFooter />
       </TodoProvider>
     </BoardLayout>
@@ -29,5 +26,3 @@ const BoardLayout = styled.section`
   background: #fff;
   border-radius: 5px;
 `;
-
-const TodoList = styled.div``;

--- a/src/pages/Board.tsx
+++ b/src/pages/Board.tsx
@@ -1,12 +1,10 @@
 /* eslint-disable react/prop-types */
-import React, { useState } from 'react';
+import React from 'react';
 import styled from '@emotion/styled';
 import Header from '../components/Header';
 import TodosHeader from '../components/TodosHeader';
 import TodoList from '../components/TodoList';
 import TodosFooter from '../components/TodosFooter';
-import { Todo } from '../types/Todo';
-import * as api from '../api/todo';
 import TodoProvider from '../contexts/todoContext';
 
 export default function Board() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -110,6 +110,13 @@
   dependencies:
     "@babel/types" "^7.15.0"
 
+"@babel/helper-module-imports@^7.10.4":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.15.4.tgz#e18007d230632dea19b47853b984476e7b4e103f"
+  integrity sha512-jeAHZbzUwdW/xHgHQ3QmWR4Jg6j15q4w/gCfwZvtqOxoo5DKtLHk8Bsf4c5RZRC7NmLEs+ohkdq8jFefuvIxAA==
+  dependencies:
+    "@babel/types" "^7.15.4"
+
 "@babel/helper-module-imports@^7.12.13", "@babel/helper-module-imports@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz#6d1a44df6a38c957aa7c312da076429f11b422f3"
@@ -235,7 +242,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
-"@babel/plugin-syntax-jsx@^7.12.13":
+"@babel/plugin-syntax-jsx@^7.12.13", "@babel/plugin-syntax-jsx@^7.14.5", "@babel/plugin-syntax-jsx@^7.2.0":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.14.5.tgz#000e2e25d8673cce49300517a3eda44c263e4201"
   integrity sha512-ohuFIsOMXJnbOMRfX7/w7LocdR6R7whhuRD4ax8IipLcLPlZGJKkBxgHp++U4N/vKyU16/YDQr2f5seajD3jIw==
@@ -297,6 +304,17 @@
   integrity sha512-u6OXzDaIXjEstBRRoBCQ/uKQKlbuaeE5in0RvWdA4pN6AhqxTIwUsnHPU1CFZA/amYObMsuWhYfRl3Ch90HD0Q==
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
+
+"@babel/plugin-transform-react-jsx@^7.12.1":
+  version "7.14.9"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.14.9.tgz#3314b2163033abac5200a869c4de242cd50a914c"
+  integrity sha512-30PeETvS+AeD1f58i1OVyoDlVYQhap/K20ZrMjLmmzmC2AYR/G43D4sdJAaDAqCD3MYpSWbmrz3kES158QSLjw==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.14.5"
+    "@babel/helper-module-imports" "^7.14.5"
+    "@babel/helper-plugin-utils" "^7.14.5"
+    "@babel/plugin-syntax-jsx" "^7.14.5"
+    "@babel/types" "^7.14.9"
 
 "@babel/plugin-transform-typescript@^7.15.0":
   version "7.15.0"
@@ -363,6 +381,14 @@
     "@babel/helper-validator-identifier" "^7.14.9"
     to-fast-properties "^2.0.0"
 
+"@babel/types@^7.14.9", "@babel/types@^7.15.4":
+  version "7.15.6"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.15.6.tgz#99abdc48218b2881c058dd0a7ab05b99c9be758f"
+  integrity sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.14.9"
+    to-fast-properties "^2.0.0"
+
 "@bcoe/v8-coverage@^0.2.3":
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
@@ -380,7 +406,14 @@
   dependencies:
     "@cspotcode/source-map-consumer" "0.8.0"
 
-"@emotion/babel-plugin@^11.0.0", "@emotion/babel-plugin@^11.3.0":
+"@emotion/babel-plugin-jsx-pragmatic@^0.1.5":
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/@emotion/babel-plugin-jsx-pragmatic/-/babel-plugin-jsx-pragmatic-0.1.5.tgz#27debfe9c27c4d83574d509787ae553bf8a34d7e"
+  integrity sha512-y+3AJ0SItMDaAgGPVkQBC/S/BaqaPACkQ6MyCI2CUlrjTxKttTVfD3TMtcs7vLEcLxqzZ1xiG0vzwCXjhopawQ==
+  dependencies:
+    "@babel/plugin-syntax-jsx" "^7.2.0"
+
+"@emotion/babel-plugin@^11.0.0", "@emotion/babel-plugin@^11.2.0", "@emotion/babel-plugin@^11.3.0":
   version "11.3.0"
   resolved "https://registry.yarnpkg.com/@emotion/babel-plugin/-/babel-plugin-11.3.0.tgz#3a16850ba04d8d9651f07f3fb674b3436a4fb9d7"
   integrity sha512-UZKwBV2rADuhRp+ZOGgNWg2eYgbzKzQXfQPtJbu/PLy8onurxlNCLvxMQEvlr1/GudguPI5IU9qIY1+2z1M5bA==
@@ -397,6 +430,16 @@
     find-root "^1.1.0"
     source-map "^0.5.7"
     stylis "^4.0.3"
+
+"@emotion/babel-preset-css-prop@^11.2.0":
+  version "11.2.0"
+  resolved "https://registry.yarnpkg.com/@emotion/babel-preset-css-prop/-/babel-preset-css-prop-11.2.0.tgz#c7e945f56b2610b438f0dc8ae5253fc55488de0e"
+  integrity sha512-9XLQm2eLPYTho+Cx1LQTDA1rATjoAaB4O+ds55XDvoAa+Z16Hhg8y5Vihj3C8E6+ilDM8SV5A9Z6z+yj0YIRBg==
+  dependencies:
+    "@babel/plugin-transform-react-jsx" "^7.12.1"
+    "@babel/runtime" "^7.7.2"
+    "@emotion/babel-plugin" "^11.2.0"
+    "@emotion/babel-plugin-jsx-pragmatic" "^0.1.5"
 
 "@emotion/cache@^11.1.3", "@emotion/cache@^11.4.0":
   version "11.4.0"
@@ -727,6 +770,14 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@rollup/plugin-babel@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-babel/-/plugin-babel-5.3.0.tgz#9cb1c5146ddd6a4968ad96f209c50c62f92f9879"
+  integrity sha512-9uIC8HZOnVLrLHxayq/PTzw+uS25E14KPUBh5ktF+18Mjo5yK0ToMMx6epY0uEgkjwJw0aBW4x2horYXh8juWw==
+  dependencies:
+    "@babel/helper-module-imports" "^7.10.4"
+    "@rollup/pluginutils" "^3.1.0"
+
 "@rollup/plugin-commonjs@^20.0.0":
   version "20.0.0"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-commonjs/-/plugin-commonjs-20.0.0.tgz#3246872dcbcb18a54aaa6277a8c7d7f1b155b745"
@@ -851,6 +902,11 @@
   version "0.0.39"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
   integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
+
+"@types/faker@^5.5.8":
+  version "5.5.8"
+  resolved "https://registry.yarnpkg.com/@types/faker/-/faker-5.5.8.tgz#6649adfdfdbb0acf95361fc48f2d0ca6e88bd1cf"
+  integrity sha512-bsl0rYsaZVHlZkynL5O04q6YXDmVjcid6MbOHWqvtE2WWs/EKhp0qchDDhVWlWyQXUffX1G83X9LnMxRl8S/Mw==
 
 "@types/graceful-fs@^4.1.2":
   version "4.1.5"
@@ -2351,6 +2407,11 @@ expect@^27.1.0:
     jest-matcher-utils "^27.1.0"
     jest-message-util "^27.1.0"
     jest-regex-util "^27.0.6"
+
+faker@^5.5.3:
+  version "5.5.3"
+  resolved "https://registry.yarnpkg.com/faker/-/faker-5.5.3.tgz#c57974ee484431b25205c2c8dc09fda861e51e0e"
+  integrity sha512-wLTv2a28wjUyWkbnX7u/ABZBkUkIF2fCd73V6P2oFqEGEktDfzWx4UxrSqtPRw0xPRAcjeAOIiJWqZm3pP4u3g==
 
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"


### PR DESCRIPTION
## Description
<!-- 이 PR이 해결하는 문제. 기존의 기능을 변경한 경우, 1. 기존 기능의 작동, 2. 어떻게 고쳤는가, 3. 왜 고쳤는가를 포함해주세요. 필요에 따라 스크린샷도 첨부해주세요! -->
context api를 활용하여 상태관리 하는 코드를 작성하다가 localstorage api가 useReducer 함수 기능을 하는 것 같다는 생각이 들었습니다. 그래서 우선 context api로 작성한 코드를 draft로 올립니다.. 추후 의견 반영하여 수정하도록 하겠습니다

- 상태 전용 context와 디스패치 전용 context를 각각 만들어 낭비되는 렌더링을 방지하였습니다. form같은 경우 상태는 필요하지 않고 디스패치만 팔요한데 상태가 업데이트될 때마다 불필요한 렌더링이 발생하기 때문입니다.
- 추후 Provider를 사용하지 않을 때를 대비하여 context의 값을 undefined도 허용해주었습니다.
- useRedcer 함수의 action 타입들이 localstorage api의 함수 종류입니다
- useTodosState와 useTodosDispatch의 커스텀 Hooks를 만들어 유효성 검사를 편리하게 해주었습니다.
- context를 사용하는 방법은 useTodosState와 useTodosDispatch를 불러와 event 함수 내에 작성해주면 됩니다.

참고한 글
- https://velog.io/@velopert/typescript-context-api
- https://react.vlpt.us/mashup-todolist/02-manage-state.html
- https://react.vlpt.us/using-typescript/04-ts-context.html


## Help Wanted 👀
<!-- 도움이 필요한 부분들을 적어주세요. -->

## Related Issues

resolve #10
fix #

## Checklist ✋

<!-- PR을 생성하기 전에 아래 체크리스트를 확인해주세요. 만족한 조건들은 (`[x]`)로 표시해주세요. -->

- [ ] PR 타이틀을 `{PR type}: {PR title}`로 맞췄습니다. (type 예시: feat | fix | BREAKING CHANGE | chore | ci | docs | style | refactor | perf | test) (참고: [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/))
- [ ] 모든 **변경점**들을 확인했으며 적절히 설명했습니다.
- [ ] 빌드와 테스트가 정상적으로 수행됨을 확인했습니다. (`npm run build`, `npm run test`)
- [ ] 깃헙 이슈를 연결하겠습니다. (커밋에 resolve #이슈넘버 적거나 PR생성 후 Linked Issue 추가)